### PR TITLE
Hide `groupmod: GID '50' already exists` error message on MacOSX

### DIFF
--- a/symfony/entrypoint.sh
+++ b/symfony/entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 
 : ${WWW_DATA_UID:=`stat -c %u /var/www/html`}
 : ${WWW_DATA_GUID:=`stat -c %g /var/www/html`}
@@ -7,11 +6,19 @@ set -e
 # Change www-data's uid & guid to be the same as directory in host
 # Fix cache problems
 if [ "`id -u www-data`" != "$WWW_DATA_UID" ]; then
-    usermod -u $WWW_DATA_UID www-data || true
+    usermod -u $WWW_DATA_UID www-data > /dev/null 2>&1
+    if [ $? != 0 ]; then
+        echo "The UID $WWW_DATA_UID is already used by another user."
+        exit 1
+    fi
 fi
 
 if [ "`id -u www-data`" != "$WWW_DATA_GUID" ]; then
-    groupmod -g $WWW_DATA_GUID www-data || true
+    groupmod -g $WWW_DATA_GUID www-data > /dev/null 2>&1
+    if [ $? != 0 ]; then
+        echo "The GUID $WWW_DATA_GUID is already used by another group."
+        exit 1
+    fi
 fi
 
 if [ "$1" = 'apache2ctl' ]; then

--- a/symfony/entrypoint.sh
+++ b/symfony/entrypoint.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 set -e
 
+: ${WWW_DATA_UID:=`stat -c %u /var/www/html`}
+: ${WWW_DATA_GUID:=`stat -c %g /var/www/html`}
+
 # Change www-data's uid & guid to be the same as directory in host
 # Fix cache problems
-usermod -u `stat -c %u /var/www/html` www-data || true
-groupmod -g `stat -c %g /var/www/html` www-data &> /dev/null || true
+if [ "`id -u www-data`" != "$WWW_DATA_UID" ]; then
+    usermod -u $WWW_DATA_UID www-data || true
+fi
+
+if [ "`id -u www-data`" != "$WWW_DATA_GUID" ]; then
+    groupmod -g $WWW_DATA_GUID www-data || true
+fi
 
 if [ "$1" = 'apache2ctl' ]; then
     # let's start as root

--- a/symfony/entrypoint.sh
+++ b/symfony/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 # Change www-data's uid & guid to be the same as directory in host
 # Fix cache problems
 usermod -u `stat -c %u /var/www/html` www-data || true
-groupmod -g `stat -c %g /var/www/html` www-data || true
+groupmod -g `stat -c %g /var/www/html` www-data &> /dev/null || true
 
 if [ "$1" = 'apache2ctl' ]; then
     # let's start as root


### PR DESCRIPTION
On MacOSX, when we use your image we always have this output : `groupmod: GID '50' already exists`.

This PR fix this.

What do you think ?
